### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Some basic instructions for building a native extension are here: [http://www.jo
 2. 	Copy the Steam SDK headers and libs:
 		
 		STEAMSDK/public/steam/*.h -> native/include/steam/*.h
-		STEAMSDK/public/redistributable_bin/steam_api.dll -> native/lib/
+		STEAMSDK/public/redistributable_bin/steam_api.dll -> native/lib/win32/
 		STEAMSDK/public/redistributable_bin/steam_api.lib -> native/lib/
 		STEAMSDK/public/redistributable_bin/osx32/libsteam_api.dylib -> native/lib/osx64/
 


### PR DESCRIPTION
Instructions are incorrect, it looks for steam_api.dll in native/lib/win32/steam_api.dll, I'm guessing that it does a similar thing for linux but haven't tested that yet.
